### PR TITLE
Add CI workflow for building Docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)


### PR DESCRIPTION
This workflow builds a Docker image on push and pull request events to the main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added continuous integration workflow for automated Docker image building and tagging, triggered on all pushes and pull requests to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->